### PR TITLE
Fixed init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -5,7 +5,8 @@ require('coc-config')
 require('lualine').setup()
 
 require'nvim-treesitter.configs'.setup {
-  ensure_installed = "maintained",
+  ensure_installed = "all",
+  ignore_install = { "phpdoc" },
   context_commentstring = {
     enable = true
   },


### PR DESCRIPTION
Tree Sitter throws an error with the depreciated `maintained` setup, I replaced it with:
```
ensure_installed = "all",
ignore_install = { "phpdoc" },
```
`phpdoc` gets ignored since it's broken